### PR TITLE
Use exit code instead of command output to check if command exists

### DIFF
--- a/CommandExec/CommandUtils.cs
+++ b/CommandExec/CommandUtils.cs
@@ -1,6 +1,3 @@
-using System;
-using System.IO;
-
 namespace CommandExec
 {
   public static class CommandUtils
@@ -10,15 +7,21 @@ namespace CommandExec
       Command cmd;
       if (Command.isUnix)
       {
-        cmd = Command.Shell($"command -v {command} &> /dev/null && echo true").RedirectStdOut();
+        cmd = Command.Shell($"command -v {command} &> /dev/null").RedirectStdOut()
+          .RedirectStdOut()
+          .RedirectStdErr()
+          .RedirectStdIn();
       }
       else
       {
-        cmd = Command.Shell($"if (Get-Command -Name {command} -ErrorAction SilentlyContinue) {{echo true}}").RedirectStdOut();
+        cmd = Command.Shell($"Get-Command -Name {command} -ErrorAction SilentlyContinue | $null")
+          .RedirectStdOut()
+          .RedirectStdErr()
+          .RedirectStdIn();
       }
 
       cmd.Run();
-      return cmd.STDOut.ReadToEnd().ReplaceLineEndings("") == "true";
+      return cmd.process.ExitCode == 0;
     }
   }
 }

--- a/CommandExec/CommandUtils.cs
+++ b/CommandExec/CommandUtils.cs
@@ -14,7 +14,7 @@ namespace CommandExec
       }
       else
       {
-        cmd = Command.Shell($"Get-Command -Name {command} -ErrorAction SilentlyContinue | $null")
+        cmd = Command.Shell($"Get-Command -Name {command} -ErrorAction SilentlyContinue > $null")
           .RedirectStdOut()
           .RedirectStdErr()
           .RedirectStdIn();


### PR DESCRIPTION
Now to check if a command exists, it's just one shell command instead of if statements and AND_IFs.